### PR TITLE
Railsの初期設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,9 @@ module RestaurantVote
     # Railsの日本語化設定
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
+
+    config.generators do |g|
+      g.helper false
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,9 @@ module RestaurantVote
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # Railsの日本語化設定
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,9 @@ module RestaurantVote
     # Don't generate system test files.
     config.generators.system_tests = nil
 
+    # Railsのタイムゾーンを日本時間に変更
+    config.time_zone = 'Tokyo'
+
     # Railsの日本語化設定
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}').to_s]


### PR DESCRIPTION
## 概要

issue #9

### Railsの初期設定
- Railsのタイムゾーンを日本時間に変更
- Railsの日本語化設定
- genetare時にhelperファイルが生成されないように設定

## 確認方法

タイムゾーン
[![Image from Gyazo](https://i.gyazo.com/5cefc5639bf7c88410ef9ab8688764b7.png)](https://gyazo.com/5cefc5639bf7c88410ef9ab8688764b7)

日本語化設定
[![Image from Gyazo](https://i.gyazo.com/eeddd374e355ba36efc9f54c4baec74b.png)](https://gyazo.com/eeddd374e355ba36efc9f54c4baec74b)

